### PR TITLE
Use symbolicmode.chmod to simplify chmod() code.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ distro               # apache2
 linux-utils          # mit
 psutil>5.9.0         # bsd
 shakenfist-utilities # apache2
-symbolicmode>=1.0    # CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+symbolicmode>=2.0    # CC0 1.0 Universal (CC0 1.0) Public Domain Dedication

--- a/shakenfist_agent/commandline/daemon.py
+++ b/shakenfist_agent/commandline/daemon.py
@@ -127,13 +127,7 @@ class SFFileAgent(protocol.FileAgent):
         self.incomplete_file_puts[path]['flo'].write(d)
 
     def chmod(self, packet):
-        mode = packet['mode']
-        try:
-            int(mode)
-        except ValueError:
-            mode = symbolicmode.symbolic_to_numeric_permissions(mode)
-
-        os.chmod(packet['path'], mode)
+        symbolicmode.chmod(packet['path'], packet['mode'])
         self.send_packet({
             'command': 'chmod-response',
             'path': packet['path'],


### PR DESCRIPTION
symbolicmode provides a chmod() method that can take symbolic or numeric permissions, so the function can be simplified.

Note, this depends on symbolicmode 2.x, because I decided (as I was reviewing the use here) that I had the order of the chmod arguments backwards, so I made the backwards-incompatible change and rolled the major version up because of that.