### PR TITLE
Fix export-repo-config workflow permissions.

### DIFF
--- a/.github/workflows/export-repo-config.yml
+++ b/.github/workflows/export-repo-config.yml
@@ -1,7 +1,8 @@
 name: Export repository configuration
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The workflow needs contents: write to push branches and pull-requests: write to create PRs. Without these, the job fails with a 403 from github-actions[bot].

Prompt: I think the export-repo-config CI job is missing a permission?