### PR TITLE
Widen renovate range strategy for grpc packages.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,13 +13,14 @@
   },
   "packageRules": [
     {
-      "description": "Group grpc packages together",
+      "description": "Group grpc packages together with widen strategy",
       "matchPackagePatterns": [
         "^grpcio",
         "^googleapis-common-protos",
         "^protobuf"
       ],
-      "groupName": "grpc packages"
+      "groupName": "grpc packages",
+      "rangeStrategy": "widen"
     },
     {
       "description": "Automatically merge minor and patch-level updates",


### PR DESCRIPTION
Use rangeStrategy "widen" for grpc packages so renovate only creates PRs for new major versions, avoiding
unnecessary churn when dependencies use >= constraints.

Prompt: For each of shakenfist/agent-python, client-python, client-python-k3s, clingwrap, and occystrap: update renovate.json to use widen rangeStrategy for grpc packages.