### PR TITLE
Relax grpc dependency pins to >= ranges.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ dependencies = [
     "symbolicmode>=2.0",                # CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
     "setproctitle",                     # bsd
 
-    "protobuf==5.29.5",                 # bsd
-    "grpcio==1.70.0",                   # apache2
-    "grpcio-status==1.70.0",            # apache2
-    "grpcio-tools==1.70.0",             # apache2
-    "googleapis-common-protos==1.70.0", # apache2
+    "protobuf>=5.29.0,<6",              # bsd
+    "grpcio>=1.70.0",                   # apache2
+    "grpcio-status>=1.70.0",            # apache2
+    "grpcio-tools>=1.70.0",             # apache2
+    "googleapis-common-protos>=1.70.0", # apache2
 ]
 
 [project.urls]


### PR DESCRIPTION
Use >= ranges instead of exact == pins for grpc and protobuf packages. This allows pip to select versions with pre-built wheels for newer Python versions (e.g. 3.14 on Fedora 43) instead of falling back to source builds that require a C++ compiler. Cap protobuf at <6 to stay within the same major version as the generated stubs.

Prompt: Propose a safe set of initial ranges for the grpc dependencies in agent-python.