### PR TITLE
Do not bind reserved vsock CIDs in the agent.

### DIFF
--- a/shakenfist_agent/commandline/daemon.py
+++ b/shakenfist_agent/commandline/daemon.py
@@ -525,11 +525,27 @@ def daemon_run(ctx):
             cid = struct.unpack('I', r)[0]
         click.echo(f'Our v2 vsock CID is {cid}.')
 
-        s = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
-        s.bind((cid, VSOCK_PORT))
-        s.listen()
-        s.settimeout(0.2)
-        click.echo('Listening for incoming v2 requests')
+        if cid < 3:
+            # CIDs 0 through 2 are reserved (the hypervisor, local loopback,
+            # and the host respectively); a real guest CID is always at
+            # least 3. We are handed VMADDR_CID_LOCAL (1) when the guest has
+            # no virtio-vsock device at all -- /dev/vsock exists because the
+            # vsock core module is loaded, but the only registered transport
+            # is loopback. That happens when the instance was created
+            # without the sf-agent2 side channel. Binding the loopback CID
+            # would listen on a socket the hypervisor can never connect to,
+            # so don't pretend the side channel works.
+            click.echo(
+                f'CID {cid} is reserved, which means this guest has no '
+                'vsock device. The instance was probably created without '
+                'the sf-agent2 side channel. Not listening for v2 '
+                'requests.')
+        else:
+            s = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+            s.bind((cid, VSOCK_PORT))
+            s.listen()
+            s.settimeout(0.2)
+            click.echo('Listening for incoming v2 requests')
 
     workers = {}
     while not EXIT.is_set():


### PR DESCRIPTION
When a guest has no virtio-vsock device, /dev/vsock still exists if the vsock core module is loaded, and IOCTL_VM_SOCKETS_GET_LOCAL_CID returns VMADDR_CID_LOCAL (1) because the loopback transport is the only one registered. The daemon bound that CID and cheerfully logged "Listening for incoming v2 requests" on a socket the hypervisor can never connect to. This is the "Our v2 vsock CID is 1" seen on the console of any Shaken Fist instance created without the sf-agent2 side channel.

CIDs 0 through 2 are reserved (hypervisor, local loopback, and host); a real guest CID is always at least 3. Treat a reserved CID as "this guest has no vsock device": log an explanation pointing at the missing side channel and skip the vsock listener instead of pretending the side channel works.

Prompt: Debug why the raptor instance on the sfcbr cluster reported "Our v2 vsock CID is 1" for sf-agent. The instance had been created without the sf-agent2 side channel (a client defaulting bug, fixed separately), and the agent was asked to handle the resulting loopback CID gracefully rather than listening on it.



Claude-Session: https://claude.ai/code/session_01Cjvy8CnKoM8EeABA2Xajuh