### PR TITLE
Use the shared automated review workflow

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -19,32 +19,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Check if the last commit was from the bot to prevent infinite
-  # loops in automated fixer jobs.
-  check-bot-commit:
-    name: "Check bot commit"
-    if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, static]
-    outputs:
-      is_bot: ${{ steps.check.outputs.is_bot }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: Check if last commit was from bot
-        id: check
-        run: |
-          LAST_AUTHOR_EMAIL=$(git log -1 --format='%ae')
-          echo "Last commit author: $LAST_AUTHOR_EMAIL"
-          if [ "$LAST_AUTHOR_EMAIL" = "bot@shakenfist.com" ]; then
-            echo "is_bot=true" >> $GITHUB_OUTPUT
-            echo "Last commit was from bot - skipping review"
-          else
-            echo "is_bot=false" >> $GITHUB_OUTPUT
-          fi
-
   # These sanity checks used to be three separate jobs, but are now combined
   # to save a little time and reduce CI runner churn.
   sanity_checks:
@@ -228,25 +202,18 @@ jobs:
 
   automated_reviewer:
     name: "Automated reviewer"
+    # The needs: list is the "review only once CI has passed" gate:
+    # a job skipped because a dependency failed never starts the
+    # reusable workflow. Everything else about the reviewer --
+    # runner, timeout, fork restriction, bot-commit check --
+    # lives in the shared workflow so it stays in step with the
+    # rest of the fleet.
+    needs: [sanity_checks]
+    # A cross-repository reusable workflow cannot grant itself more
+    # token scope than its caller has, so the permissions go here.
     permissions:
       contents: read
       pull-requests: write
-    runs-on: [self-hosted, claude-code]
-    needs: [sanity_checks, check-bot-commit]
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.check-bot-commit.outputs.is_bot != 'true'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-reviewer
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Run automated reviewer
-        uses: shakenfist/actions/review-pr-with-claude@main
-        with:
-          pr-number: ${{ github.event.pull_request.number }}
+      issues: write
+    uses: shakenfist/actions/.github/workflows/pr-auto-review.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-address-comments.yml
+++ b/.github/workflows/pr-address-comments.yml
@@ -45,6 +45,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please address comments')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
     outputs:
       authorized: ${{ steps.trigger.outputs.authorized }}
       pr_ref: ${{ steps.trigger.outputs.pr-ref }}

--- a/.github/workflows/pr-re-review.yml
+++ b/.github/workflows/pr-re-review.yml
@@ -22,6 +22,10 @@ jobs:
       contains(github.event.comment.body, '@shakenfist-bot please re-review')
     runs-on: [self-hosted, claude-code]
     name: "Re-review PR"
+    # A review typically takes a handful of minutes. Without this the
+    # job inherits the six hour GitHub default, so a wedged Claude run
+    # would hold a scarce claude-code runner for the rest of the day.
+    timeout-minutes: 60
 
     steps:
       - name: Check commenter permissions

--- a/.github/workflows/pr-retest.yml
+++ b/.github/workflows/pr-retest.yml
@@ -26,6 +26,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please retest')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
 
     steps:
       - name: Handle trigger


### PR DESCRIPTION
The automatic PR review has until now been an "automated_reviewer" job
written out in full in this repository's CI workflow, copied from a
snippet in the development repository's README. Eight projects each
carried a copy and they had drifted from one another. None of them set
timeout-minutes, so a wedged Claude Code run could hold a scarce
claude-code runner for GitHub's six hour default.

The job body now lives once, in
shakenfist/actions/.github/workflows/pr-auto-review.yml. What stays
here is the part which is genuinely per-project: the needs: list
naming this project's test jobs, which is what gates the review on CI
passing. A job skipped because a dependency failed never starts the
reusable workflow.

Adopting the shared workflow brings this project:

* A 60 minute timeout on the review. Real reviews finish in three to
  six minutes.
* The same-repository restriction. The reviewer runs Claude Code with
  --dangerously-skip-permissions while holding a token with
  pull-requests: write and issues: write, and is fed the PR diff,
  which is untrusted input, so a fork PR would put an attacker's text
  in front of a write-capable token.
* A bot-commit check which also recognises noreply@anthropic.com, the
  address a Claude Code commit made on a runner is authored as. Only
  clingwrap's copy caught that address before.

The check-bot-commit job goes with it, since the reviewer was its only
consumer and the shared workflow does that check itself over the API.
That saves a job, a static runner and a checkout on every PR.

The reviewer also gains issues: write, which it never had here at
either job or workflow level -- so the issues it tries to file for
actionable review findings could not have been created.

While here, bring the rest of the Claude Code workflow timeouts into line
with the templates: 60 minutes on the re-review, 10 on the retest trigger
and 10 on the address-comments trigger.

**Pre-existing, not from this change:** actionlint already fails on `functional-tests.yml` on develop, over `steps.commit_message` and `needs.enqueue_pr_comment` references that do not resolve. The findings are byte-identical before and after this branch. Worth a separate fix.

Validated with each project's own `pre-commit` on the changed files, and by diffing actionlint findings before and after so pre-existing noise is not mistaken for a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
