### PR TITLE
Index docs/ from AGENTS.md and ARCHITECTURE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,18 @@ messages. The agent handles commands such as executing processes,
 transferring files, gathering system facts, and checking service
 status.
 
+## Where the documentation lives
+
+| Question | Document |
+|----------|----------|
+| How is the agent put together? | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| What is the wire protocol? | [docs/protocol.md](docs/protocol.md) |
+| How do I build, test and release it? | [docs/developer-guide.md](docs/developer-guide.md) |
+| What does the agent do, from a user's point of view? | [docs/index.md](docs/index.md) |
+
+New user-visible documentation belongs in `docs/`. This file and
+`ARCHITECTURE.md` are a summary and an index into it.
+
 ## Key Patterns
 
 ### Adding a New Command

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,11 @@ The Shaken Fist in-guest agent runs inside virtual machines and
 provides a side channel for the hypervisor to interact with the
 guest OS. Communication uses protobuf over a vsock connection.
 
+This document is the map. The message-by-message wire protocol is
+[docs/protocol.md](docs/protocol.md), building and testing is
+[docs/developer-guide.md](docs/developer-guide.md), and the
+user-facing overview is [docs/index.md](docs/index.md).
+
 ## Directory Structure
 
 ```


### PR DESCRIPTION
Neither file pointed at a single page under `docs/`, despite `docs/` carrying the wire protocol reference, the developer guide and the user-facing overview. An agent reading `AGENTS.md` had no way to know that documentation existed.

This adds a **Where the documentation lives** table to `AGENTS.md` and a one-paragraph pointer to `ARCHITECTURE.md`, and states that new user-visible documentation belongs in `docs/` rather than in either of these files.

Both files are already comfortably summary-sized (91 and 161 lines), so nothing moves.

Resolves the new `llm-doc-structure` consistency audit for this repository.

> **Note:** `pre-commit run --all-files` reports pre-existing failures in the actionlint and shellcheck hooks. Both fail identically on an unmodified checkout and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)